### PR TITLE
Update for setuptools scm autoversion

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "plum-dispatch" %}
-{% set version = "1.5.2" %}
+{% set version = "1.5.3" %}
 
 
 package:
@@ -22,7 +22,9 @@ requirements:
     - pip
     - python
     - cython >=0.29
-    - setuptools >=41
+    - setuptools >=45
+    - setuptools_scm >=3.4
+    - toml
   run:
     - python
 


### PR DESCRIPTION
This should be merged right after you tag a new version of plum-dispatch.
You should also bump the version number and the hash by checking the hash of the tarball uploaded to pypi.

@wesselb